### PR TITLE
Remove firebase dependency

### DIFF
--- a/floofgg/package-lock.json
+++ b/floofgg/package-lock.json
@@ -12,7 +12,6 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
-        "firebase": "^10.12.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.23.1",

--- a/floofgg/package.json
+++ b/floofgg/package.json
@@ -7,7 +7,6 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "firebase": "^10.12.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.1",


### PR DESCRIPTION
## Summary
- remove `firebase` from dependency lists
- run `npm install` (fails in container with no network)

## Testing
- `npm install` *(fails: Exit handler never called)*