### PR TITLE
Refactor deck state into dedicated module

### DIFF
--- a/floofgg/src/pages/DeckViewer/DeckViewer.js
+++ b/floofgg/src/pages/DeckViewer/DeckViewer.js
@@ -1,6 +1,8 @@
 // src/pages/DeckViewer.js
 import React, { useState, useEffect } from 'react';
-import {handleFile, generateTestHand, test100Hands, cardValues} from '../../utils/deck';
+import { handleFile, generateTestHand, test100Hands } from '../../utils/deck';
+import deckState from '../../utils/deckState';
+const { cardValues } = deckState;
 import {loadValuesFromStorage, saveValues} from '../../utils/storage';
 
 const DeckViewer = () => {

--- a/floofgg/src/utils/combinations.js
+++ b/floofgg/src/utils/combinations.js
@@ -1,4 +1,4 @@
-import { currentCardId } from '../utils/deck.js';
+import deckState from './deckState';
 
 let combinationMode = false;
 let selectedCombinationCard = null;
@@ -9,12 +9,12 @@ export function startCombinationSetup() {
     document.getElementById('mainDeck').classList.add('combination-mode');
     combinationMode = true;
 
-    selectedCombinationCard = currentCardId;
+    selectedCombinationCard = deckState.currentCardId;
     
     // Add UI elements for combination mode
     const combinationUI = `
         <div id="combinationCard" class="card">
-            <img src="https://images.ygoprodeck.com/images/cards/${currentCardId}.jpg" alt="Card ${currentCardId}">
+            <img src="https://images.ygoprodeck.com/images/cards/${deckState.currentCardId}.jpg" alt="Card ${deckState.currentCardId}">
         </div>
         <button id="combinationWithButton">With</button>
         <button id="combinationWithoutButton">Without</button>

--- a/floofgg/src/utils/deck.js
+++ b/floofgg/src/utils/deck.js
@@ -1,6 +1,7 @@
-import {loadValuesFromStorage, saveValues} from '../utils/storage';
-import {startCombinationSetup} from '../utils/combinations';
+import { loadValuesFromStorage, saveValues } from '../utils/storage';
+import { startCombinationSetup } from '../utils/combinations';
 import { saveValuesToStorage } from '../utils/storage';
+import deckState from './deckState';
 
 document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('deckFile').addEventListener('change', handleFile, false);
@@ -31,21 +32,15 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // Attach event listeners for increment and decrement buttons
-    document.getElementById('incrementValue').addEventListener('click', () => updateCardValue(currentCardId, 1));
-    document.getElementById('decrementValue').addEventListener('click', () => updateCardValue(currentCardId, -1));
+    document.getElementById('incrementValue').addEventListener('click', () => updateCardValue(deckState.currentCardId, 1));
+    document.getElementById('decrementValue').addEventListener('click', () => updateCardValue(deckState.currentCardId, -1));
 
     // Load card values from the appropriate storage
     loadValuesFromStorage();
 });
 
-export let mainDeck = [];
-export let extraDeck = [];
-export let sideDeck = [];
-export let currentCardId = '';
-export let currentCombination = null;
-
-// Initialize card values to 0
-export const cardValues = {};
+// Reference to shared state
+const cardValues = deckState.cardValues;
 
 export function handleFile(event) {
     const file = event.target.files[0];
@@ -54,12 +49,12 @@ export function handleFile(event) {
         reader.onload = function(e) {
             const content = e.target.result;
             const decks = parseYdk(content);
-            mainDeck = decks.mainDeck;
-            extraDeck = decks.extraDeck;
-            sideDeck = decks.sideDeck;
-            displayCards(mainDeck, 'mainDeck');
-            displayCards(extraDeck, 'extraDeck');
-            displayCards(sideDeck, 'sideDeck');
+            deckState.mainDeck = decks.mainDeck;
+            deckState.extraDeck = decks.extraDeck;
+            deckState.sideDeck = decks.sideDeck;
+            displayCards(deckState.mainDeck, 'mainDeck');
+            displayCards(deckState.extraDeck, 'extraDeck');
+            displayCards(deckState.sideDeck, 'sideDeck');
         };
         reader.readAsText(file);
     }
@@ -131,7 +126,7 @@ export function displayCards(cardIds, containerId) {
 
         // Add click event to open modal with card details
         cardElement.addEventListener('click', () => {
-            currentCardId = cardId;
+            deckState.currentCardId = cardId;
             document.getElementById('cardModal').style.display = "block";
             document.getElementById('modalImage').src = `https://images.ygoprodeck.com/images/cards/${cardId}.jpg`;
             // Display card value
@@ -142,12 +137,12 @@ export function displayCards(cardIds, containerId) {
 }
 
 export function generateTestHand() {
-    if (mainDeck.length < 5) {
+    if (deckState.mainDeck.length < 5) {
         alert("Main Deck has fewer than 5 cards!");
         return;
     }
 
-    let deckCopy = [...mainDeck];
+    let deckCopy = [...deckState.mainDeck];
     const testHand = [];
     
     for (let i = 0; i < 5; i++) {
@@ -206,7 +201,7 @@ export function test100Hands() {
     let totalHandValue = 0;
 
     for (let i = 0; i < 100; i++) {
-        let deckCopy = [...mainDeck];
+        let deckCopy = [...deckState.mainDeck];
         const testHand = [];
         
         for (let j = 0; j < 5; j++) {

--- a/floofgg/src/utils/deckState.js
+++ b/floofgg/src/utils/deckState.js
@@ -1,0 +1,10 @@
+const deckState = {
+    mainDeck: [],
+    extraDeck: [],
+    sideDeck: [],
+    currentCardId: '',
+    currentCombination: null,
+    cardValues: {}
+};
+
+export default deckState;

--- a/floofgg/src/utils/storage.js
+++ b/floofgg/src/utils/storage.js
@@ -1,4 +1,5 @@
-import { cardValues, mainDeck, extraDeck, sideDeck } from './deck';
+import deckState from './deckState';
+const { cardValues, mainDeck, extraDeck, sideDeck } = deckState;
 const DEV = true; // Set to true for local development
 
 function setCookie(name, value, days) {


### PR DESCRIPTION
## Summary
- extract shared deck state to `deckState.js`
- update deck utilities to use the new state object
- update storage functions to pull state from `deckState`
- import deck state in DeckViewer and combinations scripts

## Testing
- `npm test --silent` *(fails: react-scripts not found)*