### PR TITLE
Implement comments and labels

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -19,6 +19,9 @@ import type * as cards from "../cards.js";
 import type * as http from "../http.js";
 import type * as lanes from "../lanes.js";
 import type * as router from "../router.js";
+import type * as comments from "../comments.js";
+import type * as labels from "../labels.js";
+import type * as activities from "../activities.js";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -35,6 +38,9 @@ declare const fullApi: ApiFromModules<{
   http: typeof http;
   lanes: typeof lanes;
   router: typeof router;
+  comments: typeof comments;
+  labels: typeof labels;
+  activities: typeof activities;
 }>;
 export declare const api: FilterApi<
   typeof fullApi,

--- a/convex/activities.ts
+++ b/convex/activities.ts
@@ -1,0 +1,26 @@
+import { v } from "convex/values";
+import { query } from "./_generated/server";
+import { getAuthUserId } from "@convex-dev/auth/server";
+
+export const listForCard = query({
+  args: { cardId: v.id("cards") },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const card = await ctx.db.get(args.cardId);
+    if (!card) throw new Error("Card not found");
+
+    const lane = await ctx.db.get(card.laneId);
+    if (!lane) throw new Error("Lane not found");
+
+    const board = await ctx.db.get(lane.boardId);
+    if (!board || board.userId !== userId) throw new Error("Access denied");
+
+    return await ctx.db
+      .query("activities")
+      .withIndex("by_card", q => q.eq("cardId", args.cardId))
+      .order("desc")
+      .collect();
+  }
+});

--- a/convex/comments.ts
+++ b/convex/comments.ts
@@ -1,0 +1,60 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { getAuthUserId } from "@convex-dev/auth/server";
+
+export const list = query({
+  args: { cardId: v.id("cards") },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const card = await ctx.db.get(args.cardId);
+    if (!card) throw new Error("Card not found");
+
+    const lane = await ctx.db.get(card.laneId);
+    if (!lane) throw new Error("Lane not found");
+
+    const board = await ctx.db.get(lane.boardId);
+    if (!board || board.userId !== userId) throw new Error("Access denied");
+
+    return await ctx.db
+      .query("comments")
+      .withIndex("by_card", q => q.eq("cardId", args.cardId))
+      .order("desc")
+      .collect();
+  }
+});
+
+export const add = mutation({
+  args: { cardId: v.id("cards"), text: v.string() },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const card = await ctx.db.get(args.cardId);
+    if (!card) throw new Error("Card not found");
+
+    const lane = await ctx.db.get(card.laneId);
+    if (!lane) throw new Error("Lane not found");
+
+    const board = await ctx.db.get(lane.boardId);
+    if (!board || board.userId !== userId) throw new Error("Access denied");
+
+    const id = await ctx.db.insert("comments", {
+      cardId: args.cardId,
+      userId,
+      text: args.text,
+      createdAt: Date.now(),
+    });
+
+    await ctx.db.insert("activities", {
+      cardId: args.cardId,
+      userId,
+      type: "comment",
+      text: args.text,
+      createdAt: Date.now(),
+    });
+
+    return id;
+  }
+});

--- a/convex/labels.ts
+++ b/convex/labels.ts
@@ -1,0 +1,91 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { getAuthUserId } from "@convex-dev/auth/server";
+
+export const listForBoard = query({
+  args: { boardId: v.id("boards") },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+    const board = await ctx.db.get(args.boardId);
+    if (!board || board.userId !== userId) throw new Error("Access denied");
+
+    return await ctx.db
+      .query("labels")
+      .withIndex("by_board", q => q.eq("boardId", args.boardId))
+      .collect();
+  }
+});
+
+export const create = mutation({
+  args: { boardId: v.id("boards"), name: v.string(), color: v.string() },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+    const board = await ctx.db.get(args.boardId);
+    if (!board || board.userId !== userId) throw new Error("Access denied");
+
+    return await ctx.db.insert("labels", {
+      boardId: args.boardId,
+      name: args.name,
+      color: args.color,
+    });
+  }
+});
+
+export const labelsForCard = query({
+  args: { cardId: v.id("cards") },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const card = await ctx.db.get(args.cardId);
+    if (!card) throw new Error("Card not found");
+
+    const lane = await ctx.db.get(card.laneId);
+    if (!lane) throw new Error("Lane not found");
+
+    const board = await ctx.db.get(lane.boardId);
+    if (!board || board.userId !== userId) throw new Error("Access denied");
+
+    const assigns = await ctx.db
+      .query("cardLabels")
+      .withIndex("by_card", q => q.eq("cardId", args.cardId))
+      .collect();
+
+    const labels = [] as any[];
+    for (const assign of assigns) {
+      const label = await ctx.db.get(assign.labelId);
+      if (label) labels.push(label);
+    }
+    return labels;
+  }
+});
+
+export const toggleLabelOnCard = mutation({
+  args: { cardId: v.id("cards"), labelId: v.id("labels") },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const card = await ctx.db.get(args.cardId);
+    if (!card) throw new Error("Card not found");
+
+    const lane = await ctx.db.get(card.laneId);
+    if (!lane) throw new Error("Lane not found");
+
+    const board = await ctx.db.get(lane.boardId);
+    if (!board || board.userId !== userId) throw new Error("Access denied");
+
+    const existing = await ctx.db
+      .query("cardLabels")
+      .withIndex("by_card_label", q => q.eq("cardId", args.cardId).eq("labelId", args.labelId))
+      .unique();
+
+    if (existing) {
+      await ctx.db.delete(existing._id);
+    } else {
+      await ctx.db.insert("cardLabels", { cardId: args.cardId, labelId: args.labelId });
+    }
+  }
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -24,6 +24,35 @@ const applicationTables = {
     description: v.optional(v.string()),
     position: v.number(),
   }).index("by_lane", ["laneId"]),
+
+  comments: defineTable({
+    cardId: v.id("cards"),
+    userId: v.id("users"),
+    text: v.string(),
+    createdAt: v.number(),
+  }).index("by_card", ["cardId"]),
+
+  labels: defineTable({
+    boardId: v.id("boards"),
+    name: v.string(),
+    color: v.string(),
+  }).index("by_board", ["boardId"]),
+
+  cardLabels: defineTable({
+    cardId: v.id("cards"),
+    labelId: v.id("labels"),
+  })
+    .index("by_card", ["cardId"])
+    .index("by_label", ["labelId"])
+    .index("by_card_label", ["cardId", "labelId"]),
+
+  activities: defineTable({
+    cardId: v.id("cards"),
+    userId: v.id("users"),
+    type: v.string(),
+    text: v.optional(v.string()),
+    createdAt: v.number(),
+  }).index("by_card", ["cardId"]),
 };
 
 export default defineSchema({

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Doc } from "../../convex/_generated/dataModel";
@@ -6,27 +6,20 @@ import { toast } from "sonner";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
+import { Id } from "../../convex/_generated/dataModel";
+import { CardModal } from "./CardModal";
+
 interface CardProps {
   card: Doc<"cards">;
+  boardId: Id<"boards">;
   isDragging?: boolean;
   viewMode?: "use" | "design" | "view";
 }
 
-export function Card({ card, isDragging = false, viewMode = "use" }: CardProps) {
-  const updateCard = useMutation(api.cards.update);
+export function Card({ card, boardId, isDragging = false, viewMode = "use" }: CardProps) {
   const deleteCard = useMutation(api.cards.remove);
   
-  const [isEditing, setIsEditing] = useState(false);
-  const [editTitle, setEditTitle] = useState(card.title);
-  const [editDescription, setEditDescription] = useState(card.description || "");
-
-  useEffect(() => {
-    if (viewMode !== "use") {
-      setIsEditing(false);
-      setEditTitle(card.title);
-      setEditDescription(card.description || "");
-    }
-  }, [viewMode, card.title, card.description]);
+  const [showModal, setShowModal] = useState(false);
 
   const {
     attributes,
@@ -41,7 +34,7 @@ export function Card({ card, isDragging = false, viewMode = "use" }: CardProps) 
       type: "card",
       card,
     },
-    disabled: isEditing || viewMode !== "use",
+    disabled: viewMode !== "use",
   });
 
   const style = {
@@ -49,22 +42,6 @@ export function Card({ card, isDragging = false, viewMode = "use" }: CardProps) 
     transition,
   };
 
-  const handleUpdateCard = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!editTitle.trim()) return;
-
-    try {
-      await updateCard({
-        cardId: card._id,
-        title: editTitle.trim(),
-        description: editDescription.trim() || undefined,
-      });
-      setIsEditing(false);
-      toast.success("Card updated successfully!");
-    } catch (error) {
-      toast.error("Failed to update card");
-    }
-  };
 
   const handleDeleteCard = async () => {
     if (!confirm(`Are you sure you want to delete "${card.title}"?`)) {
@@ -79,48 +56,6 @@ export function Card({ card, isDragging = false, viewMode = "use" }: CardProps) 
     }
   };
 
-  if (isEditing) {
-    return (
-      <div className="bg-white rounded-lg p-3 shadow-sm border border-gray-200">
-        <form onSubmit={handleUpdateCard}>
-          <input
-            type="text"
-            value={editTitle}
-            onChange={(e) => setEditTitle(e.target.value)}
-            className="w-full px-2 py-1 text-sm font-medium bg-white border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 mb-2"
-            placeholder="Card title"
-            autoFocus
-          />
-          <textarea
-            value={editDescription}
-            onChange={(e) => setEditDescription(e.target.value)}
-            className="w-full px-2 py-1 text-sm bg-white border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 mb-2"
-            placeholder="Card description (optional)"
-            rows={2}
-          />
-          <div className="flex gap-2">
-            <button
-              type="submit"
-              className="px-3 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
-            >
-              Save
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                setEditTitle(card.title);
-                setEditDescription(card.description || "");
-                setIsEditing(false);
-              }}
-              className="px-3 py-1 text-xs bg-gray-300 text-gray-700 rounded hover:bg-gray-400 transition-colors"
-            >
-              Cancel
-            </button>
-          </div>
-        </form>
-      </div>
-    );
-  }
 
   return (
     <div
@@ -130,7 +65,7 @@ export function Card({ card, isDragging = false, viewMode = "use" }: CardProps) 
       className={`bg-white rounded-lg p-3 shadow-sm border border-gray-200 transition-shadow group ${
         viewMode === "use" ? "cursor-pointer hover:shadow-md" : "cursor-default"
       } ${isSortableDragging || isDragging ? "opacity-50" : ""}`}
-      onClick={viewMode === "use" ? () => setIsEditing(true) : undefined}
+      onClick={viewMode === "use" ? () => setShowModal(true) : undefined}
     >
       <div className="flex justify-between items-start">
         {viewMode === "use" && (
@@ -166,5 +101,9 @@ export function Card({ card, isDragging = false, viewMode = "use" }: CardProps) 
         )}
       </div>
     </div>
+      {showModal && (
+        <CardModal card={card} boardId={boardId} onClose={() => setShowModal(false)} />
+      )}
+    </>
   );
 }

--- a/src/components/CardModal.tsx
+++ b/src/components/CardModal.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import { Doc, Id } from "../../convex/_generated/dataModel";
+import { toast } from "sonner";
+
+interface CardModalProps {
+  card: Doc<"cards">;
+  boardId: Id<"boards">;
+  onClose: () => void;
+}
+
+export function CardModal({ card, boardId, onClose }: CardModalProps) {
+  const updateCard = useMutation(api.cards.update);
+  const comments = useQuery(api.comments.list, { cardId: card._id });
+  const addComment = useMutation(api.comments.add);
+  const labels = useQuery(api.labels.listForBoard, { boardId });
+  const cardLabels = useQuery(api.labels.labelsForCard, { cardId: card._id });
+  const toggleLabel = useMutation(api.labels.toggleLabelOnCard);
+  const activities = useQuery(api.activities.listForCard, { cardId: card._id });
+
+  const [title, setTitle] = useState(card.title);
+  const [description, setDescription] = useState(card.description || "");
+  const [commentText, setCommentText] = useState("");
+
+  const handleSave = async () => {
+    await updateCard({
+      cardId: card._id,
+      title: title.trim() || card.title,
+      description: description.trim() || undefined,
+    });
+    toast.success("Card updated");
+  };
+
+  const handleAddComment = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!commentText.trim()) return;
+    await addComment({ cardId: card._id, text: commentText.trim() });
+    setCommentText("");
+  };
+
+  const handleToggleLabel = async (labelId: Id<"labels">) => {
+    await toggleLabel({ cardId: card._id, labelId });
+  };
+
+  const hasLabel = (labelId: Id<"labels">) =>
+    cardLabels?.some((l) => l._id === labelId);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-2">
+      <div className="bg-white rounded w-full max-w-xl p-4 overflow-y-auto max-h-full">
+        <div className="flex justify-between items-start mb-4">
+          <h2 className="text-lg font-semibold">Card Details</h2>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
+            ✕
+          </button>
+        </div>
+        <div className="space-y-4">
+          <div>
+            <input
+              className="w-full border rounded px-2 py-1 mb-2"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+            <textarea
+              className="w-full border rounded px-2 py-1"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+            />
+            <button
+              onClick={handleSave}
+              className="mt-2 px-3 py-1 text-sm bg-blue-600 text-white rounded"
+            >
+              Save
+            </button>
+          </div>
+
+          {labels && (
+            <div>
+              <h4 className="font-medium mb-1">Labels</h4>
+              <div className="flex flex-wrap gap-2">
+                {labels.map((label) => (
+                  <label key={label._id} className="flex items-center gap-1 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={!!hasLabel(label._id)}
+                      onChange={() => handleToggleLabel(label._id)}
+                    />
+                    <span
+                      className="px-2 py-0.5 rounded"
+                      style={{ background: label.color }}
+                    >
+                      {label.name}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div>
+            <h4 className="font-medium mb-1">Add Comment</h4>
+            <form onSubmit={handleAddComment} className="flex gap-2 mb-2">
+              <input
+                className="flex-1 border rounded px-2 py-1 text-sm"
+                value={commentText}
+                onChange={(e) => setCommentText(e.target.value)}
+                placeholder="Write a comment"
+              />
+              <button type="submit" className="px-3 py-1 bg-gray-800 text-white rounded text-sm">
+                Add
+              </button>
+            </form>
+            <div className="space-y-2">
+              {comments?.map((c) => (
+                <div key={c._id} className="bg-gray-100 p-2 rounded text-sm">
+                  <p>{c.text}</p>
+                  <div className="text-xs text-gray-500 mt-1">
+                    {new Date(c.createdAt).toLocaleString()}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {activities && (
+            <div>
+              <h4 className="font-medium mb-1">Activity</h4>
+              <div className="space-y-1 text-sm">
+                {activities.map((a) => (
+                  <div key={a._id} className="text-gray-700">
+                    {new Date(a.createdAt).toLocaleString()} - {a.type === "comment" ? `Commented: ${a.text}` : a.text}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Lane.tsx
+++ b/src/components/Lane.tsx
@@ -202,7 +202,7 @@ export function Lane({ lane, viewMode, publicView = false }: LaneProps) {
       <SortableContext items={sortedCards.map(c => c._id)} strategy={verticalListSortingStrategy}>
         <div className="space-y-3 flex-1 flex flex-col">
           {sortedCards.map((card) => (
-            <Card key={card._id} card={card} viewMode={viewMode} />
+            <Card key={card._id} card={card} boardId={lane.boardId} viewMode={viewMode} />
           ))}
         </div>
       </SortableContext>


### PR DESCRIPTION
## Summary
- expose comments, labels, and activities modules in generated API
- support comment threads, labels, and activity log in schema
- add Convex functions for comments, labels and activity listing
- show new card details modal with comments, labels, and activity
- integrate modal with lanes

## Testing
- `npm run lint` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684b3b1244bc832c95c0e277e1215346