### PR TITLE
Fix sorted arrays without mutation

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -204,7 +204,7 @@ export function Board({ boardId, publicView = false }: BoardProps) {
     );
   }
 
-  const sortedLanes = lanes.sort((a, b) => a.position - b.position);
+  const sortedLanes = [...lanes].sort((a, b) => a.position - b.position);
 
   const handleBackgroundChange = async (bg: string) => {
     await updateBoard({

--- a/src/components/Lane.tsx
+++ b/src/components/Lane.tsx
@@ -94,7 +94,7 @@ export function Lane({ lane, viewMode, publicView = false }: LaneProps) {
     );
   }
 
-  const sortedCards = cards.sort((a, b) => a.position - b.position);
+  const sortedCards = [...cards].sort((a, b) => a.position - b.position);
 
   // Use editColor when editing, otherwise use lane.color
   const currentColor = isEditing ? editColor : (lane.color || "#f3f4f6");


### PR DESCRIPTION
## Summary
- avoid in-place sorting when computing lanes and cards

## Testing
- `npm run lint` *(fails: Cannot find module 'convex/values')*

------
https://chatgpt.com/codex/tasks/task_e_684bf96f8a38832caed41b63c3fa0b3c