### PR TITLE
Add board duplication

### DIFF
--- a/convex/boards.ts
+++ b/convex/boards.ts
@@ -132,6 +132,69 @@ export const remove = mutation({
   },
 });
 
+export const duplicate = mutation({
+  args: {
+    boardId: v.id("boards"),
+    withCards: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+
+    const board = await ctx.db.get(args.boardId);
+    if (!board || board.userId !== userId) {
+      throw new Error("Board not found or access denied");
+    }
+
+    const newBoardId = await ctx.db.insert("boards", {
+      name: `${board.name} Copy`,
+      description: board.description,
+      background: board.background,
+      userId,
+      isPublic: board.isPublic,
+    });
+
+    const lanes = await ctx.db
+      .query("lanes")
+      .withIndex("by_board", (q) => q.eq("boardId", args.boardId))
+      .order("asc")
+      .collect();
+
+    const laneIdMap = new Map();
+    for (const lane of lanes) {
+      const newLaneId = await ctx.db.insert("lanes", {
+        boardId: newBoardId,
+        name: lane.name,
+        position: lane.position,
+        color: lane.color,
+      });
+      laneIdMap.set(lane._id, newLaneId);
+    }
+
+    if (args.withCards) {
+      for (const lane of lanes) {
+        const cards = await ctx.db
+          .query("cards")
+          .withIndex("by_lane", (q) => q.eq("laneId", lane._id))
+          .collect();
+
+        for (const card of cards) {
+          await ctx.db.insert("cards", {
+            laneId: laneIdMap.get(lane._id),
+            title: card.title,
+            description: card.description,
+            position: card.position,
+          });
+        }
+      }
+    }
+
+    return newBoardId;
+  },
+});
+
 export const getPublic = query({
   args: { boardId: v.id("boards") },
   handler: async (ctx, args) => {

--- a/src/components/BoardList.tsx
+++ b/src/components/BoardList.tsx
@@ -12,6 +12,7 @@ export function BoardList({ onSelectBoard }: BoardListProps) {
   const boards = useQuery(api.boards.list) || [];
   const createBoard = useMutation(api.boards.create);
   const deleteBoard = useMutation(api.boards.remove);
+  const duplicateBoard = useMutation(api.boards.duplicate);
   
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [newBoardName, setNewBoardName] = useState("");
@@ -52,6 +53,18 @@ export function BoardList({ onSelectBoard }: BoardListProps) {
       toast.success("Board deleted successfully!");
     } catch (error) {
       toast.error("Failed to delete board");
+    }
+  };
+
+  const handleDuplicateBoard = async (boardId: Id<"boards">, boardName: string) => {
+    const withCards = confirm(
+      `Do you want to also duplicate the cards in "${boardName}"? Click 'Ok' to include cards or 'Cancel' for an empty copy.`
+    );
+    try {
+      await duplicateBoard({ boardId, withCards });
+      toast.success("Board duplicated successfully!");
+    } catch (error) {
+      toast.error("Failed to duplicate board");
     }
   };
 
@@ -167,16 +180,28 @@ export function BoardList({ onSelectBoard }: BoardListProps) {
                       </p>
                     )}
                   </div>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleDeleteBoard(board._id, board.name);
-                    }}
-                    className="ml-2 p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all duration-200 opacity-0 group-hover:opacity-100"
-                    title="Delete board"
-                  >
-                    🗑️
-                  </button>
+                  <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100">
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDuplicateBoard(board._id, board.name);
+                      }}
+                      className="p-1.5 text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded-lg transition-all duration-200"
+                      title="Duplicate board"
+                    >
+                      ⧉
+                    </button>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDeleteBoard(board._id, board.name);
+                      }}
+                      className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all duration-200"
+                      title="Delete board"
+                    >
+                      🗑️
+                    </button>
+                  </div>
                 </div>
                 
                 <div className="flex items-center justify-between mt-4 pt-4 border-t border-gray-100">


### PR DESCRIPTION
## Summary
- add `boards.duplicate` mutation for copying boards (cards optional)
- add duplicate option in `BoardList`

## Testing
- `npm run lint` *(fails: Cannot find module 'convex/server')*

------
https://chatgpt.com/codex/tasks/task_e_684bf7537128832ca6d5a9d02ab185c7