### PR TITLE
Improve offline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ Check out the [Convex docs](https://docs.convex.dev/) for more information on ho
 ## HTTP API
 
 User-defined http routes are defined in the `convex/router.ts` file. We split these routes into a separate file from `convex/http.ts` to allow us to prevent the LLM from modifying the authentication routes.
+
+## Offline mode
+
+The app includes a basic service worker to cache core assets. If you're offline,
+navigation requests fall back to `offline.html`. When signing out without a
+connection, the client clears cached auth state before attempting to contact the
+server.

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Offline</title>
+  <style>
+    body { font-family: sans-serif; padding: 2rem; text-align: center; }
+  </style>
+</head>
+<body>
+  <h1>You are offline</h1>
+  <p>Some features may be unavailable.</p>
+</body>
+</html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,8 +1,9 @@
-const CACHE_NAME = 'floofgg-cache-v1';
+const CACHE_NAME = 'floofgg-cache-v2';
 const URLS_TO_CACHE = [
   '/',
   '/index.html',
-  '/manifest.json'
+  '/manifest.json',
+  '/offline.html'
 ];
 
 self.addEventListener('install', event => {
@@ -21,6 +22,15 @@ self.addEventListener('activate', event => {
 
 self.addEventListener('fetch', event => {
   event.respondWith(
-    caches.match(event.request).then(response => response || fetch(event.request))
+    caches.match(event.request).then(response => {
+      if (response) {
+        return response;
+      }
+      return fetch(event.request).catch(() => {
+        if (event.request.mode === 'navigate') {
+          return caches.match('/offline.html');
+        }
+      });
+    })
   );
 });

--- a/src/SignOutButton.tsx
+++ b/src/SignOutButton.tsx
@@ -6,6 +6,21 @@ export function SignOutButton() {
   const { isAuthenticated } = useConvexAuth();
   const { signOut } = useAuthActions();
 
+  const handleClick = async () => {
+    if (!navigator.onLine) {
+      try {
+        localStorage.removeItem("convexAuth");
+      } catch (err) {
+        console.error("Failed to clear auth state", err);
+      }
+    }
+    try {
+      await signOut();
+    } catch (err) {
+      console.error("Sign out failed", err);
+    }
+  };
+
   if (!isAuthenticated) {
     return null;
   }
@@ -13,7 +28,7 @@ export function SignOutButton() {
   return (
     <button
       className="px-4 py-2 rounded-lg text-sm font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200 transition-all duration-200 hover:shadow-sm"
-      onClick={() => void signOut()}
+      onClick={() => void handleClick()}
     >
       Sign Out
     </button>


### PR DESCRIPTION
## Summary
- add offline page and update service worker to use it
- clear cached auth if offline during sign out
- document offline mode behaviour

## Testing
- `npm run lint` *(fails: Cannot find module)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca616a5e0832cb6cf9236b3faa69a