### PR TITLE
Add card drop checklist

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Id } from "../../convex/_generated/dataModel";
+import { Id, Doc } from "../../convex/_generated/dataModel";
 import { Lane } from "./Lane";
 import { AddLane } from "./AddLane";
 import {
@@ -29,6 +29,7 @@ export function Board({ boardId, publicView = false }: BoardProps) {
   const board = useQuery(publicView ? api.boards.getPublic : api.boards.get, { boardId });
   const lanes = useQuery(publicView ? api.lanes.listPublic : api.lanes.list, { boardId });
   const moveCard = useMutation(api.cards.move);
+  const addChecklistItem = useMutation(api.checklists.add);
   const updateBoard = useMutation(api.boards.update);
   
   const [activeCard, setActiveCard] = useState<any>(null);
@@ -307,6 +308,7 @@ export function Board({ boardId, publicView = false }: BoardProps) {
       const cardId = active.id as Id<"cards">;
       const overId = over.id;
       const overData = over.data.current;
+      const draggedCard = active.data.current.card as Doc<"cards">;
 
       if (overData?.type === "lane") {
         // Moving to a different lane
@@ -324,6 +326,10 @@ export function Board({ boardId, publicView = false }: BoardProps) {
           newLaneId: targetCard.laneId,
           newPosition: targetCard.position,
         });
+      } else if (overData?.type === "cardModal") {
+        const targetCardId = overData.cardId as Id<"cards">;
+        await addChecklistItem({ cardId: targetCardId, text: draggedCard.title });
+        toast.success(`Added "${draggedCard.title}" to checklist`);
       }
     }
 

--- a/src/components/CardModal.tsx
+++ b/src/components/CardModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useMutation, useQuery } from "convex/react";
+import { useDroppable } from "@dnd-kit/core";
 import { api } from "../../convex/_generated/api";
 import { Doc, Id } from "../../convex/_generated/dataModel";
 import { toast } from "sonner";
@@ -29,6 +30,11 @@ export function CardModal({ card, boardId, onClose }: CardModalProps) {
   const [commentText, setCommentText] = useState("");
   const [itemText, setItemText] = useState("");
   const [isEditing, setIsEditing] = useState(false);
+
+  const { setNodeRef, isOver } = useDroppable({
+    id: `modal-${card._id}`,
+    data: { type: "cardModal", cardId: card._id },
+  });
 
   const handleSave = async () => {
     await updateCard({
@@ -80,7 +86,10 @@ export function CardModal({ card, boardId, onClose }: CardModalProps) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-2">
-      <div className="bg-white rounded w-full max-w-xl p-4 overflow-y-auto max-h-full">
+      <div
+        ref={setNodeRef}
+        className={`bg-white rounded w-full max-w-xl p-4 overflow-y-auto max-h-full ${isOver ? 'ring-2 ring-blue-500' : ''}`}
+      >
         <div className="flex justify-between items-start mb-4">
           <h2 className="text-lg font-semibold">Card Details</h2>
           <button onClick={onClose} className="text-gray-500 hover:text-gray-700">


### PR DESCRIPTION
## Summary
- support card drop onto open card modal
- highlight modal when dragging over

## Testing
- `npm run lint` *(fails: Cannot find module 'convex/values' etc. due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684cf6dbb998832cb7d15fd7cc5c3e4f