### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,17 @@
 # Kanban Application
-A Kanban board application built with Convex, React, and Tailwind CSS.
-  
-This is a project built with [Chef](https://chef.convex.dev) using [Convex](https://convex.dev) as its backend.
-  
-This project is connected to the Convex deployment named [`patient-parakeet-616`](https://dashboard.convex.dev/d/patient-parakeet-616).
-  
+
+A simple Kanban board for organizing tasks. Create cards, move them between columns, and track progress through your workflow.
+
+## Running the application
+
+Install dependencies and start the development server with:
+
+```bash
+npm install
+npm run dev
+```
+
 ## Project structure
-  
-The frontend code is in the `app` directory and is built with [Vite](https://vitejs.dev/).
-  
-The backend code is in the `convex` directory.
-  
-`npm run dev` will start the frontend and backend servers.
 
-## App authentication
-
-Chef apps use [Convex Auth](https://auth.convex.dev/) with Anonymous auth for easy sign in. You may wish to change this before deploying your app.
-
-## Developing and deploying your app
-
-Check out the [Convex docs](https://docs.convex.dev/) for more information on how to develop with Convex.
-* If you're new to Convex, the [Overview](https://docs.convex.dev/understanding/) is a good place to start
-* Check out the [Hosting and Deployment](https://docs.convex.dev/production/) docs for how to deploy your app
-* Read the [Best Practices](https://docs.convex.dev/understanding/best-practices/) guide for tips on how to improve you app further
-
-## HTTP API
-
-User-defined http routes are defined in the `convex/router.ts` file. We split these routes into a separate file from `convex/http.ts` to allow us to prevent the LLM from modifying the authentication routes.
+- `floofgg/` – client code
+- `convex/` – server code


### PR DESCRIPTION
## Summary
- simplify root README to describe the Kanban board
- remove references to Convex, Chef, and dev instructions

## Testing
- `npm run lint` *(fails: cannot find modules)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cff3a7f6c832ca58219f111175a0e