### PR TITLE
Fix pinch zoom when distance zero

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -345,6 +345,7 @@ export function Board({ boardId, publicView = false }: BoardProps) {
 
   const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
     if (e.touches.length === 2) {
+      e.preventDefault();
       const dx = e.touches[0].clientX - e.touches[1].clientX;
       const dy = e.touches[0].clientY - e.touches[1].clientY;
       pinchState.current.distance = Math.hypot(dx, dy);
@@ -353,10 +354,18 @@ export function Board({ boardId, publicView = false }: BoardProps) {
   };
 
   const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
-    if (e.touches.length === 2 && pinchState.current.distance) {
+    if (e.touches.length === 2 && pinchState.current.distance !== null) {
+      e.preventDefault();
       const dx = e.touches[0].clientX - e.touches[1].clientX;
       const dy = e.touches[0].clientY - e.touches[1].clientY;
       const distance = Math.hypot(dx, dy);
+
+      if (pinchState.current.distance === 0) {
+        if (distance === 0) return;
+        pinchState.current.distance = distance;
+        return;
+      }
+
       const scale = distance / pinchState.current.distance;
       let newZoom = pinchState.current.zoom * scale;
       newZoom = Math.min(1.5, Math.max(0.5, newZoom));


### PR DESCRIPTION
## Summary
- allow pinch zoom to start when touches overlap
- prevent browser touch defaults from interfering

## Testing
- `npm run lint` *(fails: Cannot find module '@convex-dev/auth/server' ...)*

------
https://chatgpt.com/codex/tasks/task_e_684d00754b60832c8e8ddaad7f42d736