### PR TITLE
Fix board layout overflow on mobile

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -377,7 +377,7 @@ export function Board({ boardId, publicView = false }: BoardProps) {
       }} 
       className="flex-1 relative w-full min-h-screen"
     >
-      <div className="w-full px-4 sm:px-6 lg:px-8 py-6">
+      <div className="w-full px-0 sm:px-6 lg:px-8 py-6">
         <div className="mb-4 sm:mb-6">
           {isEditingName ? (
             <form
@@ -781,7 +781,7 @@ export function Board({ boardId, publicView = false }: BoardProps) {
           onTouchMove={handleTouchMove}
           onTouchEnd={handleTouchEnd}
           style={{ transform: `scale(${laneZoom})`, transformOrigin: 'top left' }}
-          className="flex gap-2 sm:gap-4 lg:gap-6 overflow-x-auto pb-6 scrollbar-hide px-2 sm:px-0"
+          className="flex gap-2 sm:gap-4 lg:gap-6 overflow-x-auto pb-6 scrollbar-hide px-0"
         >
           <SortableContext items={sortedLanes.map(l => l._id)} strategy={horizontalListSortingStrategy}>
             {sortedLanes.map((lane) => (

--- a/src/index.css
+++ b/src/index.css
@@ -14,7 +14,6 @@
 html, body {
   margin: 0;
   padding: 0;
-  overflow-x: hidden;
   background: #f5f7fa;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- remove global horizontal overflow restriction
- adjust board header padding for mobile
- remove extra horizontal padding from lane container

## Testing
- `npm run lint` *(fails: Cannot find module 'convex/values')*

------
https://chatgpt.com/codex/tasks/task_e_684d0579c97c832cb847c872ba1d45f1