### PR TITLE
Fix mobile kanban layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,6 @@
         background-color: #f5f7fa;
         margin: 0;
         padding: 0;
-        overflow-x: hidden;
       }
       
       /* Prevent zoom on input focus on iOS */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,15 @@ function AppRoutes() {
           <Navbar />
         </>
       )}
-      <main className={`flex-1 ${location.pathname.startsWith("/board") || location.pathname.startsWith("/duel") ? "" : "p-4"}`}>
+      <main
+        className={`flex-1 ${
+          location.pathname.startsWith("/board") ||
+          location.pathname.startsWith("/kanban") ||
+          location.pathname.startsWith("/duel")
+            ? ""
+            : "p-4"
+        }`}
+      >
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/top-floof" element={<TopFloof />} />


### PR DESCRIPTION
## Summary
- allow horizontal scrolling by removing `overflow-x: hidden`
- avoid page padding on `/kanban` route so the board can span full width

## Testing
- `npm run lint` *(fails: Cannot find module '@convex-dev/auth/server')*
- `npm test --prefix floofgg -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d17ba90a4832ca88d42b0a122d5a8