### PR TITLE
Fix mobile lane scrolling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -16,6 +16,7 @@ html, body {
   padding: 0;
   background: #f5f7fa;
   min-height: 100vh;
+  overflow-x: hidden; /* prevent page from growing wider than the viewport */
 }
 
 body {


### PR DESCRIPTION
## Summary
- prevent body from expanding horizontally on mobile by hiding horizontal overflow

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d4be3c60c832ca908259618e47d26